### PR TITLE
COBRA-2875 - A few fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ vendor/
 *.dll
 *.so
 *.dylib
+.env*
+region-api
 
 # Test binary, build with `go test -c`
 *.test

--- a/app/deployment.go
+++ b/app/deployment.go
@@ -18,20 +18,32 @@ import (
 	"fmt"
 )
 
-func AddAlamoConfigVars(appname string, space string) []structs.EnvVar {
-	var elist []structs.EnvVar
-	var spaceconfigvar structs.EnvVar
-	var appconfigvar structs.EnvVar
-	var fullappname structs.EnvVar
-	spaceconfigvar.Name = "ALAMO_SPACE"
-	spaceconfigvar.Value = space
-	elist = append(elist, spaceconfigvar)
-	appconfigvar.Name = "ALAMO_DEPLOYMENT"
-	appconfigvar.Value = appname
-	elist = append(elist, appconfigvar)
-	fullappname.Name = "ALAMO_APPLICATION"
-	fullappname.Value = appname + "-" + space
-	elist = append(elist, fullappname)
+func AddAkkerisConfigVars(appname string, space string) []structs.EnvVar {
+	elist := make([]structs.EnvVar, 0)
+	elist = append(elist, structs.EnvVar{
+		Name:"ALAMO_SPACE",
+		Value:space,
+	})
+	elist = append(elist, structs.EnvVar{
+		Name:"AKKERIS_SPACE",
+		Value:space,
+	})
+	elist = append(elist, structs.EnvVar{
+		Name:"ALAMO_DEPLOYMENT",
+		Value:appname,
+	})
+	elist = append(elist, structs.EnvVar{
+		Name:"AKKERIS_DEPLOYMENT",
+		Value:appname,
+	})
+	elist = append(elist, structs.EnvVar{
+		Name:"ALAMO_APPLICATION",
+		Value:appname + "-" + space,
+	})
+	elist = append(elist, structs.EnvVar{
+		Name:"AKKERIS_APPLICATION",
+		Value:appname + "-" + space,
+	})
 	return elist
 }
 
@@ -88,8 +100,8 @@ func GetAllConfigVars(db *sql.DB, params martini.Params, r render.Render) {
 		utils.ReportError(err, r)
 		return
 	}
-	// Assemble config -- alamo "built in config", "user defined config vars", "service configvars"
-	elist := AddAlamoConfigVars(appname, space)
+	// Assemble config -- akkeris "built in config", "user defined config vars", "service configvars"
+	elist := AddAkkerisConfigVars(appname, space)
 	for n, v := range configvars {
 		elist = append(elist, structs.EnvVar{Name: n, Value: v})
 	}
@@ -220,8 +232,8 @@ func Deployment(db *sql.DB, deploy1 structs.Deployspec, berr binding.Errors, r r
 		configvars["PORT"] = "4747"
 	}
 
-	// Assemble config -- alamo "built in config", "user defined config vars", "service configvars"
-	elist := AddAlamoConfigVars(appname, space)
+	// Assemble config -- akkeris "built in config", "user defined config vars", "service configvars"
+	elist := AddAkkerisConfigVars(appname, space)
 	for n, v := range configvars {
 		elist = append(elist, structs.EnvVar{Name: n, Value: v})
 	}

--- a/app/oneoff.go
+++ b/app/oneoff.go
@@ -86,7 +86,7 @@ func OneOffDeployment(db *sql.DB, oneoff1 structs.OneOffSpec, berr binding.Error
 	}
 
 	// Assembly config
-	elist := AddAlamoConfigVars(appname, space)
+	elist := AddAkkerisConfigVars(appname, space)
 	// add user specific vars
 	for n, v := range configvars {
 		elist = append(elist, structs.EnvVar{Name: n, Value: v})

--- a/jobs/cronjobs.go
+++ b/jobs/cronjobs.go
@@ -295,7 +295,7 @@ func DeployCronJob(db *sql.DB, params martini.Params, req structs.JobDeploy, ber
 		return
 	}
 
-	elist := app.AddAlamoConfigVars(jobName, space)
+	elist := app.AddAkkerisConfigVars(jobName, space)
 	for n, v := range configvars {
 		elist = append(elist, structs.EnvVar{Name: n, Value: v})
 	}

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -289,7 +289,7 @@ func DeployJob(db *sql.DB, params martini.Params, req structs.JobDeploy, berr bi
 		return
 	}
 
-	elist := app.AddAlamoConfigVars(jobName, space)
+	elist := app.AddAkkerisConfigVars(jobName, space)
 	for n, v := range configvars {
 		elist = append(elist, structs.EnvVar{Name: n, Value: v})
 	}

--- a/router/dns.go
+++ b/router/dns.go
@@ -496,6 +496,8 @@ func (dnsProvider *AwsDNSProvider) DomainRecords(domain Domain) ([]DomainRecord,
 
 func (dnsProvider *AwsDNSProvider) CreateDomainRecord(domain Domain, recordType string, name string, values []string) error {
 	name = strings.ToLower(name)
+	t := time.NewTicker(time.Millisecond * 500)
+	<-t.C // in order to not exceed our throttle rate
 	_, err := dnsProvider.client.ChangeResourceRecordSets(&route53.ChangeResourceRecordSetsInput{
 		HostedZoneId: aws.String(domain.ProviderId),
 		ChangeBatch: &route53.ChangeBatch{
@@ -542,6 +544,8 @@ func (dnsProvider *AwsDNSProvider) CreateDomainRecord(domain Domain, recordType 
 
 func (dnsProvider *AwsDNSProvider) RemoveDomainRecord(domain Domain, recordType string, name string, values []string) error {
 	name = strings.ToLower(name)
+	t := time.NewTicker(time.Millisecond * 500)
+	<-t.C // in order to not exceed our throttle rate
 	_, err := dnsProvider.client.ChangeResourceRecordSets(&route53.ChangeResourceRecordSetsInput{
 		HostedZoneId: aws.String(domain.ProviderId),
 		ChangeBatch: &route53.ChangeBatch{

--- a/router/ingress-istio.go
+++ b/router/ingress-istio.go
@@ -323,7 +323,7 @@ func newHostToService(input string) string {
 }
 
 func slashIt(input string) string {
-	if input[len(input) - 1] == "/" {
+	if input[len(input) - 1] == '/' {
 		return input
 	}
 	return input + "/"

--- a/router/ingress-istio.go
+++ b/router/ingress-istio.go
@@ -189,7 +189,7 @@ var vstemplate = `{
                     }
                 ],
                 "rewrite": {
-                    "uri": "{{$value.ReplacePath}}"
+                    "uri": "{{ slashIt $value.ReplacePath}}"
                 },
                 "route": [
                     {
@@ -320,6 +320,13 @@ func newHostToService(input string) string {
 	app := strings.Join(hostnamea[:len(hostnamea)-1], "-")
 	space := hostnamea[len(hostnamea)-1]
 	return app + "." + space + ".svc.cluster.local"
+}
+
+func slashIt(input string) string {
+	if input[len(input) - 1] == "/" {
+		return input
+	}
+	return input + "/"
 }
 
 func removeSlashSlash(input string) string {

--- a/router/ingress-istio.go
+++ b/router/ingress-istio.go
@@ -189,7 +189,7 @@ var vstemplate = `{
                     }
                 ],
                 "rewrite": {
-                    "uri": "{{ slashIt $value.ReplacePath}}"
+                    "uri": "{{ slashit $value.ReplacePath}}"
                 },
                 "route": [
                     {
@@ -831,6 +831,7 @@ func (ingress *IstioIngress) CreateOrUpdateRouter(router structs.Routerspec) err
 		"newhosttoservice": newHostToService,
 		"removeslashslash": removeSlashSlash,
 		"removeslash":      removeSlash,
+		"slashit":			slashIt,
 	}
 	if exists {
 		router.ResourceVersion = version


### PR DESCRIPTION
1. Moves to using `apps/v1` and off of `extensions/v1beta1` for Kubernetes APIs
2. Renames Alamo to akkeris environment variables (although leaves Alamo prefixed ones)
3. Fixes a missing slash for deep-uri-rewrites on Istio.