### PR TITLE
create v2 schema with initial function stubs

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2,11 +2,6 @@ package server
 
 import (
 	"database/sql"
-	"github.com/go-martini/martini"
-	"github.com/martini-contrib/auth"
-	"github.com/martini-contrib/binding"
-	"github.com/martini-contrib/render"
-	"github.com/robfig/cron"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -28,6 +23,12 @@ import (
 	"region-api/vault"
 	"strings"
 	"time"
+
+	"github.com/go-martini/martini"
+	"github.com/martini-contrib/auth"
+	"github.com/martini-contrib/binding"
+	"github.com/martini-contrib/render"
+	"github.com/robfig/cron"
 )
 
 func GetInfo(db *sql.DB, params martini.Params, r render.Render) {
@@ -142,7 +143,6 @@ func InitOldServiceEndpoints(m *martini.ClassicMartini) {
 	m.Get("/v1/service/influxdb/url/:servicename", service.GetInfluxdbURL)
 	m.Post("/v1/service/influxdb/instance", binding.Json(structs.Provisionspec{}), service.ProvisionInfluxdb)
 	m.Delete("/v1/service/influxdb/instance/:servicename", service.DeleteInfluxdb)
-
 
 	m.Get("/v1/service/rabbitmq/plans", service.Getrabbitmqplans)
 	m.Post("/v1/service/rabbitmq/instance", binding.Json(structs.Provisionspec{}), service.Provisionrabbitmq)
@@ -296,6 +296,9 @@ func Server(db *sql.DB) *martini.ClassicMartini {
 
 	InitOpenServiceBrokerEndpoints(db, m)
 	InitOldServiceEndpoints(m)
+
+	// Add V2 Endpoints
+	initV2Endpoints(m)
 
 	vault.GetVaultListPeriodic()
 	c := cron.New()

--- a/server/v2.go
+++ b/server/v2.go
@@ -1,0 +1,125 @@
+package server
+
+import (
+	"region-api/app"
+	"region-api/config"
+	"region-api/jobs"
+	"region-api/maintenance"
+	"region-api/service"
+	"region-api/space"
+	"region-api/structs"
+	"region-api/templates"
+	"region-api/utils"
+
+	"github.com/go-martini/martini"
+	"github.com/martini-contrib/binding"
+)
+
+func initV2Endpoints(m *martini.ClassicMartini) {
+
+	/****************************
+	*
+	*	 Modified from V1 Schema
+	*
+	****************************/
+
+	// "from apps,spacesapps"
+	m.Delete("/v2beta1/app/:appname", app.DeleteAppV2)
+	m.Post("/v2beta1/app/deploy", binding.Json(structs.Deployspec{}), app.DeploymentV2)
+	m.Get("/v2beta1/space/:space/app/:appname/configvars", app.GetAllConfigVarsV2)
+	m.Post("/v2beta1/app/deploy/oneoff", binding.Json(structs.OneOffSpec{}), app.OneOffDeploymentV2)
+	m.Get("/v2beta1/app/:appname", app.DescribeAppV2)
+
+	// "from apps"
+	m.Get("/v2beta1/apps", app.ListAppsV2)
+
+	// "from spacesapps"
+	m.Get("/v2beta1/space/:space/app/:appname", app.DescribeAppInSpaceV2)
+	m.Get("/v2beta1/space/:space/apps", app.DescribeSpaceV2)
+	m.Put("/v2beta1/space/:space/app/:app/plan", binding.Json(structs.Spaceappspec{}), space.UpdateAppPlanV2)
+	m.Put("/v2beta1/space/:space/app/:app/healthcheck", binding.Json(structs.Spaceappspec{}), space.UpdateAppHealthCheckV2)
+	m.Delete("/v2beta1/space/:space/app/:app/healthcheck", space.DeleteAppHealthCheckV2)
+	m.Delete("/v2beta1/space/:space/app/:app", space.DeleteAppV2)
+	m.Put("/v2beta1/space/:space/app/:app/scale", binding.Json(structs.Spaceappspec{}), space.ScaleAppV2)
+	m.Put("/v2beta1/space/:space/app/:app", binding.Json(structs.Spaceappspec{}), space.AddAppV2)
+	m.Delete("/v2beta1/space/:space", binding.Json(structs.Spacespec{}), space.DeleteSpaceV2)
+
+	/****************************
+	*
+	*	 Unchanged from V1 Schema
+	*
+	****************************/
+
+	m.Get("/v2beta1/config/sets", config.Listsets)
+	m.Get("/v2beta1/config/set/:setname", config.Dumpset)
+	m.Delete("/v2beta1/config/set/:setname", config.Deleteset)
+	m.Post("/v2beta1/config/set/:parent/include/:child", config.Includeset)
+	m.Delete("/v2beta1/config/set/:parent/include/:child", config.Deleteinclude)
+	m.Post("/v2beta1/config/set", binding.Json(structs.Setspec{}), config.Createset)
+	m.Post("/v2beta1/config/set/configvar", binding.Json([]structs.Varspec{}), config.Addvars)
+	m.Patch("/v2beta1/config/set/configvar", binding.Json(structs.Varspec{}), config.Updatevar)
+	m.Get("/v2beta1/config/set/:setname/configvar/:varname", config.Getvar)
+	m.Delete("/v2beta1/config/set/:setname/configvar/:varname", config.Deletevar)
+
+	m.Post("/v2beta1/app", binding.Json(structs.Appspec{}), app.Createapp)
+	m.Patch("/v2beta1/app", binding.Json(structs.Appspec{}), app.Updateapp)
+	m.Post("/v2beta1/app/bind", binding.Json(structs.Bindspec{}), app.Createbind)
+	m.Delete("/v2beta1/app/:appname/bind/:bindspec", app.Unbindapp)
+	m.Get("/v2beta1/space/:space/app/:app/instance", app.GetInstances)
+	m.Get("/v2beta1/space/:space/app/:appname/instance/:instanceid/log", app.GetAppLogs)
+	m.Delete("/v2beta1/space/:space/app/:app/instance/:instanceid", app.DeleteInstance)
+	m.Post("/v2beta1/space/:space/app/:app/instance/:instance/exec", binding.Json(structs.Exec{}), app.Exec)
+	m.Get("/v2beta1/apps/plans", app.GetPlans)
+	m.Post("/v2beta1/space/:space/app/:app/rollback/:revision", app.Rollback)
+	m.Post("/v2beta1/space/:space/app/:appname/bind", binding.Json(structs.Bindspec{}), app.Createbind)
+	m.Delete("/v2beta1/space/:space/app/:appname/bind/**", app.Unbindapp)
+	m.Post("/v2beta1/space/:space/app/:appname/bindmap/:bindtype/:bindname", binding.Json(structs.Bindmapspec{}), app.Createbindmap)
+	m.Get("/v2beta1/space/:space/app/:appname/bindmap/:bindtype/:bindname", app.Getbindmaps)
+	m.Delete("/v2beta1/space/:space/app/:appname/bindmap/:bindtype/:bindname/:mapid", app.Deletebindmap)
+	m.Get("/v2beta1/space/:space/app/:appname/configvars/:bindtype/:bindname", app.GetServiceConfigVars)
+	m.Post("/v2beta1/space/:space/app/:appname/restart", app.Restart)
+	m.Get("/v2beta1/space/:space/app/:app/status", app.Spaceappstatus)
+	m.Get("/v2beta1/kube/podstatus/:space/:app", app.PodStatus)
+
+	m.Get("/v2beta1/spaces", space.Listspaces)
+	m.Post("/v2beta1/space", binding.Json(structs.Spacespec{}), space.Createspace)
+	m.Get("/v2beta1/space/:space", space.Space)
+	m.Put("/v2beta1/space/:space/tags", binding.Json(structs.Spacespec{}), space.UpdateSpaceTags)
+
+	m.Get("/v2beta1/octhc/kube", utils.Octhc)
+	m.Get("/v2beta1/octhc/service/rabbitmq", service.Getrabbitmqplans)
+	m.Get("/v2beta1/octhc/kubesystem", utils.GetKubeSystemPods)
+
+	m.Get("/v2beta1/jobs", jobs.GetJobs)
+	m.Post("/v2beta1/jobs", binding.Json(structs.JobReq{}), jobs.CreateJob)
+	m.Put("/v2beta1/jobs", binding.Json(structs.JobReq{}), jobs.UpdateJob)
+	m.Get("/v2beta1/space/:space/jobs", jobs.GetJobsSpace)
+	m.Get("/v2beta1/space/:space/jobs/run", jobs.GetDeployedJobs)
+	m.Get("/v2beta1/space/:space/jobs/:jobName", jobs.GetJob)
+	m.Delete("/v2beta1/space/:space/jobs/:jobName", jobs.DeleteJob)
+	m.Get("/v2beta1/space/:space/jobs/:jobName/run", jobs.GetDeployedJob)
+	m.Post("/v2beta1/space/:space/jobs/:jobName/run", binding.Json(structs.JobDeploy{}), jobs.DeployJob)
+	m.Post("/v2beta1/space/:space/jobs/:jobName/scale/:replicas/:timeout", jobs.ScaleJob)
+	m.Delete("/v2beta1/space/:space/jobs/:jobName/run", jobs.StopJob)
+	m.Delete("/v2beta1/space/:space/jobs/:jobName/clean", jobs.CleanJobs)
+
+	m.Get("/v2beta1/cronjobs", jobs.GetCronJobs)
+	m.Post("/v2beta1/cronjobs", binding.Json(structs.JobReq{}), jobs.CreateCronJob)
+	m.Put("/v2beta1/cronjobs", binding.Json(structs.JobReq{}), jobs.UpdateCronJob)
+	m.Get("/v2beta1/space/:space/cronjobs", jobs.GetCronJobsSpace)
+	m.Get("/v2beta1/space/:space/cronjobs/run", jobs.GetDeployedCronJobs)
+	m.Get("/v2beta1/space/:space/cronjobs/:jobName", jobs.GetCronJob)
+	m.Delete("/v2beta1/space/:space/cronjobs/:jobName", jobs.DeleteCronJob)
+	m.Get("/v2beta1/space/:space/cronjobs/:jobName/run", jobs.GetDeployedCronJob)
+	m.Post("/v2beta1/space/:space/cronjobs/:jobName/run", binding.Json(structs.JobDeploy{}), jobs.DeployCronJob)
+	m.Put("/v2beta1/space/:space/cronjobs/:jobName/run", binding.Json(structs.JobDeploy{}), jobs.UpdatedDeployedCronJob)
+	m.Delete("/v2beta1/space/:space/cronjobs/:jobName/run", jobs.StopCronJob)
+
+	m.Post("/v2beta1/space/:space/app/:app/maintenance", maintenance.EnableMaintenancePage)
+	m.Delete("/v2beta1/space/:space/app/:app/maintenance", maintenance.DisableMaintenancePage)
+	m.Get("/v2beta1/space/:space/app/:app/maintenance", maintenance.MaintenancePageStatus)
+
+	m.Get("/v2beta1/utils/service/space/:space/app/:app", utils.GetService)
+	m.Get("/v2beta1/utils/nodes", utils.GetNodes)
+	m.Get("/v2beta1/utils/urltemplates", templates.GetURLTemplates)
+}


### PR DESCRIPTION
First step in consolidating the apps and spacesapps tables.

- Created a place to define V2 endpoints
- Created new V2 functions for things I'm pretty sure I'll need to modify (i.e. functions that use the tables)
- New V2 functions are currently unchanged code from V1 functions
