### PR TITLE
COBRA-3756 - Optimistically update and fail back to create rather tha…

### DIFF
--- a/router/ingress-istio.go
+++ b/router/ingress-istio.go
@@ -412,7 +412,7 @@ func (ingress *IstioIngress) InstallOrUpdateGateway(domain string, gateway *Gate
 	if err != nil {
 		return err
 	}
-	if code == http.StatusNotFound {
+	if code == http.StatusNotFound || code == http.StatusConflict {
 		body, code, err := ingress.runtime.GenericRequest("post", "/apis/" + IstioNetworkingAPIVersion + "/namespaces/sites-system/gateways", gateway)
 		if err != nil {
 			return err


### PR DESCRIPTION
In Kubernetes pulling a resource, then modifying it and re-applying it can sometimes fail with `409 Conflict` if the resourceVersion has updated on the server during the time you pulled an object then tried to write it (search 409 here: https://www.oreilly.com/library/view/managing-kubernetes/9781492033905/ch04.html).  

In addition, there seems to be a bug where kubernetes will report a `409 Conflict` during a `PUT` operation if the resource does not in-fact exist (https://github.com/kubernetes/kubernetes/issues/89985). 

This changes the logic when a gateway is installed or updated to "optimistically" assume the resource exists and try and perform an update with the `PUT` method, then fall back to a `POST` method if it receives a `409 Conflict` or a `404 Not Found`.

Previously the logic would get the existing gateway, update some values, then ask for the gateway to be updated on kubernetes, in the process of updating the resource on kubernetes it would first perform a `GET` method to see if it should subsequently perform a `PUT` or `POST`.  This delay in fetching the object (or the actual act of fetching the object) left enough time for the objects resourceVersion on the service to update and thus fail with a conflict. 

Hopefully this fixes it 🤞 