### PR TITLE
COBRA-3818 OSB binding request will send servicename(UUID)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,16 @@
 PKGS := $(shell go list ./... | grep -v vendor | grep -v service)
+SRC := $(shell find . \( -iname '*.go' ! -iname "*test.go" \))
 GOPATH := $(shell go env GOPATH)
 GOROOT := $(shell go env GOROOT)
 
 .PHONY: test
-server: *.go
-	GO111MODULE=on GOPATH=$(GOPATH) GOROOT=$(GOROOT) go build -v .
+
+region-api: $(SRC)
+	GO111MODULE=on GOPATH=$(GOPATH) GOROOT=$(GOROOT) go build -v -o region-api .
+
 clean:
 	GO111MODULE=on GOPATH=$(GOPATH) GOROOT=$(GOROOT) go clean
+	-rm region-api
+
 test:
 	GO111MODULE=on GOPATH=$(GOPATH) GOROOT=$(GOROOT) go test -v $(PKGS)

--- a/service/configvars.go
+++ b/service/configvars.go
@@ -47,7 +47,7 @@ func GetServiceConfigVars(db *sql.DB, appname string, space string, appbindings 
 			// if nothing else matches see if we match an
 			// open service broker that dynamically registered.
 		} else if IsOSBService(servicetype) {
-			vars, err := GetOSBBindingCredentials(servicetype, servicename, appname+"-"+space)
+			vars, err := GetOSBBindingCredentials(servicetype, servicename, servicename)
 			if err != nil {
 				return err, elist
 			}


### PR DESCRIPTION
Region-api was sending appname-spacename to OSB brokers on binding requests. This will change to use the servicename, which is a uuid.