### PR TITLE
fix commands for one off dyno

### DIFF
--- a/app/oneoff.go
+++ b/app/oneoff.go
@@ -148,6 +148,10 @@ func OneOffDeployment(db *sql.DB, oneoff1 structs.OneOffSpec, berr binding.Error
 	deployment.Image = appimage
 	deployment.Tag = apptag
 
+	if len(oneoff1.Command) > 0 {
+		deployment.Command = oneoff1.Command
+	}
+
 	if oneoff1.RunID != "" {
 		deployment.Annotations = make(map[string]string)
 		deployment.Annotations["logtrain.akkeris.io/drains"] = "persistent://" + oneoff1.RunID

--- a/structs/structs.go
+++ b/structs/structs.go
@@ -417,7 +417,7 @@ type OneOffSpec struct {
 	Podname string            `json:"podname"`
 	Image   string            `json:"image"`
 	Plan    string            `json:"plan"`
-	Command string            `json:"command,omitempty"`
+	Command []string          `json:"command,omitempty"`
 	Env     []EnvVar          `json:"env,omitempty"`
 	Labels  map[string]string `json:"labels,omitempty"`
 	RunID   string            `json:"runid,omitempty"`


### PR DESCRIPTION
Fixes commands for one-off dynos - the Command field of the OneOffSpec is correctly a slice of strings and, if exists in the payload, is added to the deployment spec.