### PR TITLE
OSB Caching Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ This uses jetstack's cert-manager (if installed) to issue certificates. By defau
 * `DEBUG_K8S` - print out all k8s calls, set to true
 * `INGRESS_DEBUG` - print out debug information on ingress, set to true
 * `MARTINI_ENV` - Always set this to `production`. See https://github.com/go-martini/martini#martini-env
+* `DEBUG_OSB` - Print out debug information on OSB calls
 
 Note that dependencies are managed via `dep` command line tool, run `dep ensure` before building.
 

--- a/service/open-service-brokers.go
+++ b/service/open-service-brokers.go
@@ -120,30 +120,30 @@ func getProvider(serviceUrl string) (*providerInfo, error) {
 		}
 		config.EnableAlphaFeatures = true // necessary for GetBinding
 
-		if os.Getenv("OSB_DEBUG") == "true" {
-			fmt.Printf("[osb] Connecting to OSB provider at %s...\n", config.URL)
+		if os.Getenv("DEBUG_OSB") == "true" {
+			log.Printf("[osb] Connecting to OSB provider at %s...\n", config.URL)
 		}
 
 		client, err := osb.NewClient(config)
 		if err != nil {
-			if os.Getenv("OSB_DEBUG") == "true" {
-				fmt.Printf("[osb] Error creating OSB client!\n[osb]    %v\n", err)
+			if os.Getenv("DEBUG_OSB") == "true" {
+				log.Printf("[osb] Error creating OSB client!\n[osb]    %v\n", err)
 			}
 			return nil, err
 		}
 		s, err := client.GetCatalog()
 		if err != nil {
-			if os.Getenv("OSB_DEBUG") == "true" {
-				fmt.Printf("[osb] Error getting OSB catalog!\n[osb]    %v\n", err)
+			if os.Getenv("DEBUG_OSB") == "true" {
+				log.Printf("[osb] Error getting OSB catalog!\n[osb]    %v\n", err)
 			}
 			return nil, err
 		}
 		service := providerInfo{serviceUrl: serviceUrl, client: client, services: s.Services}
 
-		if os.Getenv("OSB_DEBUG") == "true" {
-			fmt.Printf("[osb] Found services:\n")
+		if os.Getenv("DEBUG_OSB") == "true" {
+			log.Printf("[osb] Found services:\n")
 			for _, svc := range s.Services {
-				fmt.Printf("[osb]    %s (%v plans) - %v\n", svc.Name, len(svc.Plans), svc.Description)
+				log.Printf("[osb]    %s (%v plans) - %v\n", svc.Name, len(svc.Plans), svc.Description)
 			}
 		}
 


### PR DESCRIPTION
The OSB services are cached in a variable that is cleared every 30 minutes. If there is an issue with retrieving any of the OSB services then _none_ of the services are cached, even those that were successfully retrieved.

Now, the code calls each OSB to retrieve services and gracefully handles failures so that successfully retrieved services are still cached.

This also adds a new environment variable (`DEBUG_OSB`) that can be used to print additional information on fetching services from OSBs.