### PR TITLE
Add labels to one-off pods

### DIFF
--- a/app/oneoff.go
+++ b/app/oneoff.go
@@ -147,6 +147,7 @@ func OneOffDeployment(db *sql.DB, oneoff1 structs.OneOffSpec, berr binding.Error
 	deployment.MemoryLimit = memorylimit
 	deployment.Image = appimage
 	deployment.Tag = apptag
+	deployment.Labels = oneoff1.Labels
 
 	if len(oneoff1.Command) > 0 {
 		deployment.Command = oneoff1.Command


### PR DESCRIPTION
Forgot to include the labels on one-off pods (necessary for apps-watcher)